### PR TITLE
Add status codes to responses

### DIFF
--- a/src/main/java/com/sap/cloud/service/flags/demo/controller/DemoController.java
+++ b/src/main/java/com/sap/cloud/service/flags/demo/controller/DemoController.java
@@ -2,12 +2,15 @@ package com.sap.cloud.service.flags.demo.controller;
 
 import java.util.Optional;
 
+import javax.servlet.http.HttpServletResponse;
+
+import com.sap.cloud.service.flags.demo.service.FeatureFlagsService;
+import com.sap.cloud.service.flags.demo.service.FlagStatus;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-
-import com.sap.cloud.service.flags.demo.service.FeatureFlagsService;
 
 /**
  * Represents a controller that uses the feature toggling practice.
@@ -52,17 +55,23 @@ public class DemoController {
 	 *            - ID of the feature flag
 	 * @param modelMap
 	 *            - the {@link ModelMap}
+	 * @param rsp
+	 *            - the {@link HttpServletResponse}
 	 * 
 	 * @return the evaluation view
 	 */
 
 	@GetMapping("/evaluate/{id}")
-	public String evaluate(@PathVariable final String id, final ModelMap modelMap) {
+	public String evaluate(@PathVariable final String id, final ModelMap modelMap, final HttpServletResponse rsp) {
 		String status;
 		if (!hasBoundServiceInstance()) {
 			status = "missing-service-instance";
+			rsp.setStatus(500);
 		} else {
 			status = featureFlagsServiceOptional.get().getFlagStatus(id).toString();
+			if (status.equals(FlagStatus.MISSING.toString())) {
+				rsp.setStatus(404);
+			}
 		}
 
 		modelMap.addAttribute("status", status);


### PR DESCRIPTION
## Motivation

We noticed that this application always returns the status code `200`. Even if the feature toggle couldn't be found or the service is not even there.
This makes it hard to use this application as automated e2e test scenarios as we can not check for the status code but we have to check the body of the returned HTML content.

## Solution
In this PR we added the status code `500` if the service instance is missing and `404` if the feature toggle couldn't be found.
Everything else still returns `200`.

Tagging my pair: @phil9909