### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/resources/static/js/index.js
+++ b/src/main/resources/static/js/index.js
@@ -4,7 +4,9 @@ $(document).ready(function () {
     evaluationAnchor.click(function (event) {
         var name = $('#feature-flag-name-input').val();
         var identifier = $('#feature-flag-identifier-input').val();
-        var href = `/evaluate/${name}?identifier=${identifier}`;
+        var encodedName = encodeURIComponent(name);
+        var encodedIdentifier = encodeURIComponent(identifier);
+        var href = `/evaluate/${encodedName}?identifier=${encodedIdentifier}`;
         evaluationAnchor.attr('href', href);
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/SAP-samples/cloud-cf-feature-flags-sample/security/code-scanning/2](https://github.com/SAP-samples/cloud-cf-feature-flags-sample/security/code-scanning/2)

Use contextual encoding for URL components before assigning to `href`.

Best fix here: encode both user-controlled values with `encodeURIComponent` and then build the URL from those encoded values. This preserves functionality (still navigates to `/evaluate/<name>?identifier=<identifier>`) while preventing special characters from being interpreted as control/meta characters in the URL.

Edit only `src/main/resources/static/js/index.js` in the click handler:
- Add `encodedName` and `encodedIdentifier` variables using `encodeURIComponent(...)`.
- Build `href` from those encoded variables.
- Keep the rest of logic unchanged.

No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
